### PR TITLE
Timer and DMA files

### DIFF
--- a/LPC1769/DMA_ADC/src/main.c
+++ b/LPC1769/DMA_ADC/src/main.c
@@ -38,6 +38,8 @@
 #define ADC_CHANNEL     ADC_CHANNEL_7 /* Using ADC channel 7 */
 #define DMA_BUFFER_SIZE 16            /* Buffer size for averaging */
 
+#define OUTPUT 1 // GPIO direction for output
+
 /* Global Variables */
 static uint16_t adc_dma_buffer[DMA_BUFFER_SIZE]; /* Buffer to store ADC results */
 static uint32_t adc_avg_value = 0;

--- a/LPC1769/TIMER/src/main.c
+++ b/LPC1769/TIMER/src/main.c
@@ -154,6 +154,14 @@ void TIMER0_IRQHandler(void)
     }
 }
 
+/**
+ * @brief Start Timer0.
+ */
+void start_timer(void)
+{
+    TIM_Cmd(LPC_TIM0, ENABLE); /* Start Timer0 */
+}
+
 int main(void)
 {
     SystemInit(); // Initialize system clock


### PR DESCRIPTION
- start_timer() wasnt defined on Timer example
- OUTPUT wasnt defined on DMA example